### PR TITLE
Add base resources for an AWS Elasticsearch setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,73 @@
 
 Terraform module to setup all resources needed for setting up an AWS Elasticsearch Service domain.
 
+## awselasticseacrh
+
+### Available variables
+
+* [`project`]: String(required): Project name
+* [`environment`]: String(required): Environment name
+* [`name`]: String(optional, \"es\"): Name to use for the Elasticsearch domain
+* [`version`]: String(optional, \"5.5\": Version of the Elasticsearch domain
+* [`access_policies`]: String(optional, \"\"): IAM policy document specifying the access policies for Elasticsearch
+* [`advanced_options`]: List(optional, []): An Elasticsearch advanced_options block, which consists of Elasticsearch configuration options as key-value pairs
+* [`logging_enabled`]: Bool(optional, false): Whether to enable Elasticsearch slow logs in Cloudwatch
+* [`logging_retention`]: Int(optional, 30): How many days to retain Elasticsearch logs in Cloudwatch
+* [`instance_count`]: Int(optional, 1): Size of the Elasticsearch domain
+* [`instance_type`]: String(optional, t2.small.elasticsearch): Instance type to use for the Elasticsearch domain
+* [`dedicated_master_enabled`]: Bool(optional, false): Whether dedicated master nodes are enabled for the domain
+* [`dedicated_master_type`]: String(optional, t2.small.elasticsearch): Instance type of the dedicated master nodes in the domain
+* [`dedicated_master_count`]: Int(optional, 1): Number of dedicated master nodes in the domain
+* [`volume_type`]: String(optional, \"gp2\"): EBS volume type to use for the Elasticsearch domain
+* [`volume_size`]: Int(required): EBS volume size (in GB) to use for the Elasticsearch domain
+* [`volume_iops`]: Int(required if volume_type=\"io1\"): Amount of provisioned IOPS for the EBS volume
+* [`vpc_id`]: String(required): VPC ID where to deploy the Elasticsearch domain
+* [`subnet_ids`]: List(required): Subnet IDs for the Elasticsearch domain endpoints to be created in
+* [`security_group_ids`]: List(optional): Extra security group IDs to attach to the Elasticsearch domain. Note: a default SG is already created and exposed via outputs
+* [`snapshot_start_hour`]: Int(optional, 3): Hour during which an automated daily snapshot is taken of the Elasticsearch indices
+* [`snapshot_bucket_enabled`]: Bool(optional, false): Whether to create a bucket for custom Elasticsearch backups (other than the default daily one)
+* [`tags`]: Map(optional, {}): Optional tags
+
+### Outputs
+
+* [`arn`]: ARN of the Elasticsearch domain
+* [`domain_id`]: ID of the Elasticsearch domain
+* [`domain_name`]: Name of the Elasticsearch domain
+* [`endpoint`]: DNS endpoint of the Elasticsearch domain
+* [`sg_id`]: ID of the Elasticsearch security group
+* [`role_arn`]: ARN of the IAM role (eg to attach to an instance or user) allowing access to the Elasticsearch snapshot bucket
+* [`role_id`]: ID of the IAM role (eg to attach to an instance or user) allowing access to the Elasticsearch snapshot bucket
+
+### Example
+
+```terraform
+module "elasticsearch" {
+  source                   = "github.com/skyscrapers/terraform-awselasticsearch?ref=0.1"
+  name                     = "es"
+  project                  = "${var.project}"
+  environment              = "${terraform.workspace}"
+  version                  = "5.5"
+  instance_count           = 2
+  instance_type            = "t2.medium.elasticsearch"
+  volume_size              = 100
+  vpc_id                   = "${data.terraform_remote_state.static.vpc_id}"
+  subnet_ids               = ["${slice(data.terraform_remote_state.static.db_subnets,0,var.es_instance_count)}"]
+  dedicated_master_enabled = false
+  access_policies          = "${data.aws_iam_policy_document.es_policy.json}"
+
+  advanced_options {
+    "indices.fielddata.cache.size"           = ""
+    "rest.action.multi.allow_explicit_index" = "true"
+  }
+}
+```
 
 ## Backups
 
+The AWS Elasticsearch Service handles backups automatically via daily snapshots. You can control when this happens by setting `snapshot_start_hour`.
+
+It's possible to create a custom backup schedule by using the normal Elasticsearch API for snapshotting. This module can create an S3 bucket and IAM role allowing such scenario's (`snapshot_bucket_enabled = true`). More info on how to create custom snapshots can be found in the [AWS documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html).
+
 ## Logging
+
+This module by default creates Cloudwatch Log Groups & IAM permissions for ElasticSearch slow logging, but we don't enable these logs by default. You can control logging behavior via the `logging_enabled` and `logging_retention` parameters. When enabling this, make sure you also enable this on Elasticsearch side, following the [AWS documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-slow-logs).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # terraform-awselasticsearch
-Terraform module to setup all resources needed for setting upaan AWS Elasticsearch Service cluster.
+
+Terraform module to setup all resources needed for setting up an AWS Elasticsearch Service domain.
+
+
+## Backups
+
+## Logging

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,55 @@
+resource "aws_iam_role" "role" {
+  count       = "${var.snapshot_bucket_enabled ? 1 : 0}"
+  name        = "${var.project}-${var.environment}-${var.name}-snapshot"
+  description = "Role used for the Elasticsearch domain"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "es.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy" "snapshot_policy" {
+  count       = "${var.snapshot_bucket_enabled ? 1 : 0}"
+  name        = "${var.project}-${var.environment}-${var.name}-snapshot"
+  description = "Policy allowing the Elasticsearch domain access to the snapshots S3 bucket"
+
+  policy = <<POLICY
+{
+  "Version":"2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "iam:PassRole"
+      ],
+      "Effect":"Allow",
+      "Resource": [
+        "${aws_s3_bucket.snapshot.arn}",
+        "${aws_s3_bucket.snapshot.arn}/*"
+      ]
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "snapshot_policy_attachment" {
+  count      = "${var.snapshot_bucket_enabled ? 1 : 0}"
+  role       = "${aws_iam_role.role.id}"
+  policy_arn = "${aws_iam_policy.snapshot_policy.arn}"
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,51 +1,71 @@
-resource "aws_iam_role" "role" {
-  count       = "${var.snapshot_bucket_enabled ? 1 : 0}"
-  name        = "${var.project}-${var.environment}-${var.name}-snapshot"
-  description = "Role used for the Elasticsearch domain"
+data "aws_iam_policy_document" "cwl_policy" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
 
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "es.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
+    resources = [
+      "${aws_cloudwatch_log_group.cwl_index.arn}:*",
+      "${aws_cloudwatch_log_group.cwl_search.arn}:*",
+    ]
+
+    principals {
+      identifiers = ["es.amazonaws.com"]
+      type        = "Service"
     }
-  ]
+  }
 }
-POLICY
+
+data "aws_iam_policy_document" "snapshot_policy" {
+  count  = "${var.snapshot_bucket_enabled ? 1 : 0}"
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "iam:PassRole",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.snapshot.arn}",
+      "${aws_s3_bucket.snapshot.arn}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "assume_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      identifiers = ["es.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "cwl_resource_policy" {
+  policy_name     = "${var.project}-${var.environment}-${var.name}-cwl-policy"
+  policy_document = "${data.aws_iam_policy_document.cwl_policy.json}"
+}
+
+resource "aws_iam_role" "role" {
+  count              = "${var.snapshot_bucket_enabled ? 1 : 0}"
+  name               = "${var.project}-${var.environment}-${var.name}-snapshot"
+  description        = "Role used for the Elasticsearch domain"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_policy.json}"
 }
 
 resource "aws_iam_policy" "snapshot_policy" {
   count       = "${var.snapshot_bucket_enabled ? 1 : 0}"
   name        = "${var.project}-${var.environment}-${var.name}-snapshot"
   description = "Policy allowing the Elasticsearch domain access to the snapshots S3 bucket"
-
-  policy = <<POLICY
-{
-  "Version":"2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject",
-        "s3:PutObject",
-        "s3:DeleteObject",
-        "iam:PassRole"
-      ],
-      "Effect":"Allow",
-      "Resource": [
-        "${aws_s3_bucket.snapshot.arn}",
-        "${aws_s3_bucket.snapshot.arn}/*"
-      ]
-    }
-  ]
-}
-POLICY
+  policy      = "${data.aws_iam_policy_document.snapshot_policy.json}"
 }
 
 resource "aws_iam_role_policy_attachment" "snapshot_policy_attachment" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 resource "aws_elasticsearch_domain" "es" {
   domain_name           = "${var.project}-${var.environment}-${var.name}"
-  access_policies       = "${var.access_policies}"
   advanced_options      = "${var.advanced_options}"
   elasticsearch_version = "${var.version}"
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aws_elasticsearch_domain" "es" {
     dedicated_master_enabled = "${var.dedicated_master_enabled}"
     dedicated_master_count   = "${var.dedicated_master_count}"
     dedicated_master_type    = "${var.dedicated_master_type}"
-    zone_awareness_enabled   = true
+    zone_awareness_enabled   = "${var.zone_awareness_enabled}"
   }
 
   ebs_options {

--- a/main.tf
+++ b/main.tf
@@ -21,9 +21,15 @@ resource "aws_elasticsearch_domain" "es" {
   }
 
   log_publishing_options {
-    enabled                  = true
-    log_type                 = "${var.log_type}"
-    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.cwl.arn}"
+    enabled                  = "${var.logging_enabled}"
+    log_type                 = "INDEX_SLOW_LOGS"
+    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.cwl_index.arn}"
+  }
+
+  log_publishing_options {
+    enabled                  = "${var.logging_enabled}"
+    log_type                 = "SEARCH_SLOW_LOGS"
+    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.cwl_search.arn}"
   }
 
   snapshot_options {
@@ -48,13 +54,22 @@ resource "aws_elasticsearch_domain" "es" {
   }"
 }
 
-resource "aws_cloudwatch_log_group" "cwl" {
-  name              = "${var.project}-${var.environment}-${var.name}"
-  retention_in_days = "${var.log_retention}"
+resource "aws_cloudwatch_log_group" "cwl_index" {
+  name              = "${var.project}/${var.environment}/${var.name}/index_slow_logs"
+  retention_in_days = "${var.logging_retention}"
 
   tags = "${merge("${var.tags}",
-    map("Name", "${var.project}-${var.environment}-${var.name}",
-      "Environment", "${var.environment}",
+    map("Environment", "${var.environment}",
+      "Project", "${var.project}"))
+  }"
+}
+
+resource "aws_cloudwatch_log_group" "cwl_search" {
+  name              = "${var.project}/${var.environment}/${var.name}/search_slow_logs"
+  retention_in_days = "${var.logging_retention}"
+
+  tags = "${merge("${var.tags}",
+    map("Environment", "${var.environment}",
       "Project", "${var.project}"))
   }"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "aws_elasticsearch_domain" "es" {
   domain_name           = "${var.project}-${var.environment}-${var.name}"
-  access_policies       = "${var.access_policies}"
+  # access_policies       = "${var.access_policies}"
   advanced_options      = "${var.advanced_options}"
   elasticsearch_version = "${var.version}"
 
@@ -8,8 +8,8 @@ resource "aws_elasticsearch_domain" "es" {
     instance_count           = "${var.instance_count}"
     instance_type            = "${var.instance_type}"
     dedicated_master_enabled = "${var.dedicated_master_enabled}"
-    dedicated_master_count   = "${var.dedicated_master_count}"
-    dedicated_master_type    = "${var.dedicated_master_type}"
+    dedicated_master_count   = "${var.dedicated_master_enabled ? var.dedicated_master_count : 0}"
+    dedicated_master_type    = "${var.dedicated_master_enabled ? var.dedicated_master_type : ""}"
     zone_awareness_enabled   = "${var.zone_awareness_enabled}"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "aws_elasticsearch_domain" "es" {
   domain_name           = "${var.project}-${var.environment}-${var.name}"
-  # access_policies       = "${var.access_policies}"
+  access_policies       = "${var.access_policies}"
   advanced_options      = "${var.advanced_options}"
   elasticsearch_version = "${var.version}"
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aws_elasticsearch_domain" "es" {
     dedicated_master_enabled = "${var.dedicated_master_enabled}"
     dedicated_master_count   = "${var.dedicated_master_enabled ? var.dedicated_master_count : 0}"
     dedicated_master_type    = "${var.dedicated_master_enabled ? var.dedicated_master_type : ""}"
-    zone_awareness_enabled   = "${var.zone_awareness_enabled}"
+    zone_awareness_enabled   = "${var.instance_count > 1 ? true : false}"
   }
 
   ebs_options {

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,83 @@
+resource "aws_elasticsearch_domain" "es" {
+  domain_name           = "${var.project}-${var.environment}-${var.name}"
+  access_policies       = "${var.access_policies}"
+  advanced_options      = ["${var.advanced_options}"]
+  elasticsearch_version = "${var.version}"
+
+  cluster_config {
+    instance_count           = "${var.instance_count}"
+    instance_type            = "${var.instance_type}"
+    dedicated_master_enabled = "${var.dedicated_master_enabled}"
+    dedicated_master_count   = "${var.dedicated_master_count}"
+    dedicated_master_type    = "${var.dedicated_master_type}"
+    zone_awareness_enabled   = true
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "${var.volume_type}"
+    volume_size = "${var.volume_size}"
+    iops        = "${var.volume_type == "io1" ? var.volume_iops : 0}"
+  }
+
+  log_publishing_options {
+    enabled                  = true
+    log_type                 = "${var.log_type}"
+    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.cwl.arn}"
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = "${var.snapshot_start_hour}"
+  }
+
+  vpc_options {
+    security_group_ids = ["${aws_security_group.sg.id}", "${var.security_group_ids}"]
+    subnet_ids         = ["${var.subnet_ids}"]
+  }
+
+  # TF has no support yet for encryption at rest. Waiting for the PR to be merged:
+  # https://github.com/terraform-providers/terraform-provider-aws/pull/2632
+  # encrypt_at_rest {
+  #   enabled = "${var.encrypt_at_rest}"
+  # }
+
+  tags = "${merge("${var.tags}",
+    map("Name", "${var.project}-${var.environment}-${var.name}",
+      "Environment", "${var.environment}",
+      "Project", "${var.project}"))
+  }"
+}
+
+resource "aws_cloudwatch_log_group" "cwl" {
+  name              = "${var.project}-${var.environment}-${var.name}"
+  retention_in_days = "${var.log_retention}"
+
+  tags = "${merge("${var.tags}",
+    map("Name", "${var.project}-${var.environment}-${var.name}",
+      "Environment", "${var.environment}",
+      "Project", "${var.project}"))
+  }"
+}
+
+resource "aws_s3_bucket" "snapshot" {
+  count  = "${var.snapshot_bucket_enabled ? 1 : 0}"
+  bucket = "${var.project}-${var.environment}-${var.name}-snapshot"
+  acl    = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+  tags = "${merge("${var.tags}",
+    map("Name", "${var.project}-${var.environment}-${var.name}-snapshot",
+      "Environment", "${var.environment}",
+      "Project", "${var.project}"))
+  }"
+}
+
+# IAM elasticsearch > s3
+# IAM elasticsearch > cwlogs

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "aws_elasticsearch_domain" "es" {
   domain_name           = "${var.project}-${var.environment}-${var.name}"
   access_policies       = "${var.access_policies}"
-  advanced_options      = ["${var.advanced_options}"]
+  advanced_options      = "${var.advanced_options}"
   elasticsearch_version = "${var.version}"
 
   cluster_config {
@@ -78,6 +78,3 @@ resource "aws_s3_bucket" "snapshot" {
       "Project", "${var.project}"))
   }"
 }
-
-# IAM elasticsearch > s3
-# IAM elasticsearch > cwlogs

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,5 +15,15 @@ output "endpoint" {
 
 output "sg_id" {
   description = "ID of the Elasticsearch security group"
-  value       = "${aws_security_group.sg.sg_id}"
+  value       = "${aws_security_group.sg.id}"
+}
+
+output "role_arn" {
+  description = "ARN of the IAM role (eg to attach to an instance or user) allowing access to the Elasticsearch snapshot bucket"
+  value       = "${aws_iam_role.role.*.arn}"
+}
+
+output "role_id" {
+  description = "ID of the IAM role (eg to attach to an instance or user) allowing access to the Elasticsearch snapshot bucket"
+  value       = "${aws_iam_role.role.*.unique_id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,19 @@
+output "arn" {
+  description = "ARN of the Elasticsearch domain"
+  value       = "${aws_elasticsearch_domain.es.arn}"
+}
+
+output "domain_id" {
+  description = "ID of the Elasticsearch domain"
+  value       = "${aws_elasticsearch_domain.es.domain_id}"
+}
+
+output "endpoint" {
+  description = "DNS endpoint of the Elasticsearch domain"
+  value       = "${aws_elasticsearch_domain.es.endpoint}"
+}
+
+output "sg_id" {
+  description = "ID of the Elasticsearch security group"
+  value       = "${aws_security_group.sg.sg_id}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "domain_id" {
   value       = "${aws_elasticsearch_domain.es.domain_id}"
 }
 
+output "domain_name" {
+  description = "Name of the Elasticsearch domain"
+  value       = "${aws_elasticsearch_domain.es.domain_name}"
+}
+
 output "endpoint" {
   description = "DNS endpoint of the Elasticsearch domain"
   value       = "${aws_elasticsearch_domain.es.endpoint}"

--- a/sg.tf
+++ b/sg.tf
@@ -1,0 +1,11 @@
+resource "aws_security_group" "sg" {
+  name        = "${var.project}-${var.environment}-${var.name}"
+  description = "Security group for the ${var.project} Elasticsearch domain"
+  vpc_id      = "${var.vpc_id}"
+
+  tags = "${merge("${var.tags}",
+    map("Name", "${var.project}-${var.environment}-${var.name}",
+      "Environment", "${var.environment}",
+      "Project", "${var.project}"))
+  }"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,8 +22,8 @@ variable "access_policies" {
 
 variable "advanced_options" {
   description = "List(optional, []): An Elasticsearch advanced_options block, which consists of Elasticsearch configuration options as key-value pairs"
-  type        = "list"
-  default     = []
+  type        = "map"
+  default     = {}
 }
 
 variable "logging_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,12 +26,12 @@ variable "advanced_options" {
   default     = []
 }
 
-variable "log_type" {
-  description = "String(optional, \"INDEX_SLOW_LOGS\"): A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS"
-  default     = "INDEX_SLOW_LOGS"
+variable "logging_enabled" {
+  description = "Bool(optional, false): Whether to enable Elasticsearch slow logs in Cloudwatch"
+  default     = false
 }
 
-variable "log_retention" {
+variable "logging_retention" {
   description = "Int(optional, 30): How many days to retain Elasticsearch logs in Cloudwatch"
   default     = 30
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,11 +15,6 @@ variable "version" {
   default     = "5.5"
 }
 
-variable "access_policies" {
-  description = "String(optional, \"\"): IAM policy document specifying the access policies for Elasticsearch"
-  default     = ""
-}
-
 variable "advanced_options" {
   description = "List(optional, []): An Elasticsearch advanced_options block, which consists of Elasticsearch configuration options as key-value pairs"
   type        = "map"

--- a/variables.tf
+++ b/variables.tf
@@ -105,3 +105,7 @@ variable "tags" {
   type        = "map"
   default     = {}
 }
+
+variable "zone_awareness_enabled" {
+  default = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,107 @@
+variable "project" {
+  description = "String(required): Project name"
+}
+
+variable "environment" {
+  description = "String(required): Environment name"
+}
+
+variable "name" {
+  description = "String(optional, \"es\"): Name to use for the Elasticsearch domain"
+}
+
+variable "version" {
+  description = "String(optional, \"5.5\": Version of the Elasticsearch domain"
+  default     = "5.5"
+}
+
+variable "access_policies" {
+  description = "String(optional, \"\"): IAM policy document specifying the access policies for Elasticsearch"
+  default     = ""
+}
+
+variable "advanced_options" {
+  description = "List(optional, []): An Elasticsearch advanced_options block, which consists of Elasticsearch configuration options as key-value pairs"
+  type        = "list"
+  default     = []
+}
+
+variable "log_type" {
+  description = "String(optional, \"INDEX_SLOW_LOGS\"): A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS"
+  default     = "INDEX_SLOW_LOGS"
+}
+
+variable "log_retention" {
+  description = "Int(optional, 30): How many days to retain Elasticsearch logs in Cloudwatch"
+  default     = 30
+}
+
+variable "instance_count" {
+  description = "Int(optional, 1): Size of the Elasticsearch domain"
+  default     = 1
+}
+
+variable "instance_type" {
+  description = "String(optional, t2.small.elasticsearch): Instance type to use for the Elasticsearch domain"
+  default     = "t2.small.elasticsearch"
+}
+
+variable "dedicated_master_enabled" {
+  description = "Bool(optional, false): Whether dedicated master nodes are enabled for the domain"
+  default     = false
+}
+
+variable "dedicated_master_type" {
+  description = "String(optional, t2.small.elasticsearch): Instance type of the dedicated master nodes in the domain"
+  default     = "t2.small.elasticsearch"
+}
+
+variable "dedicated_master_count" {
+  description = "Int(optional, 1): Number of dedicated master nodes in the domain"
+  default     = 1
+}
+
+variable "volume_type" {
+  description = "String(optional, \"gp2\"): EBS volume type to use for the Elasticsearch domain"
+  default     = "gp2"
+}
+
+variable "volume_size" {
+  description = "Int(required): EBS volume size (in GB) to use for the Elasticsearch domain"
+}
+
+variable "volume_iops" {
+  description = "Int(required if volume_type=\"io1\"): Amount of provisioned IOPS for the EBS volume"
+  default     = 0
+}
+
+variable "vpc_id" {
+  description = "String(required): VPC ID where to deploy the Elasticsearch domain"
+}
+
+variable "subnet_ids" {
+  description = "List(required): Subnet IDs for the Elasticsearch domain endpoints to be created in"
+  type        = "list"
+}
+
+variable "security_group_ids" {
+  description = "List(optional): Extra security group IDs to attach to the Elasticsearch domain. Note: a default SG is already created and exposed via outputs"
+  type        = "list"
+  default     = []
+}
+
+variable "snapshot_start_hour" {
+  description = "Int(optional, 3): Hour during which an automated daily snapshot is taken of the Elasticsearch indices"
+  default     = 3
+}
+
+variable "snapshot_bucket_enabled" {
+  description = "Bool(optional, false): Whether to create a bucket for custom Elasticsearch backups (other than the default daily one)"
+  default     = false
+}
+
+variable "tags" {
+  description = "Map(optional, {}): Optional tags"
+  type        = "map"
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -105,7 +105,3 @@ variable "tags" {
   type        = "map"
   default     = {}
 }
-
-variable "zone_awareness_enabled" {
-  default = true
-}


### PR DESCRIPTION
## Description
Adds all base resources needed for setting up the AWS Elasticsearch Service inside a VPC.

## Related issues
https://github.com/skyscrapers/persistence/issues/17
https://github.com/skyscrapers/surveyanyplace/issues/286