### PR TITLE
Fix outputting the SG ID (workaround if null)

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "endpoint" {
 
 output "sg_id" {
   description = "ID of the Elasticsearch security group"
-  value       = "${format("%s", aws_security_group.sg.*.id)}"
+  value       = "${join("", aws_security_group.sg.*.id)}"
 }
 
 output "role_arn" {


### PR DESCRIPTION
Fix for correctly outputting the SG ID `es_logs_sg_id = sg-e665a89c` instead of `es_logs_sg_id = [{Variable (TypeString): sg-e665a89c}]`