### PR TITLE
Fix version and advanced options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`project`]: String(required): Project name
 * [`environment`]: String(required): Environment name
 * [`name`]: String(optional, \"es\"): Name to use for the Elasticsearch domain
-* [`version`]: String(optional, \"6.0\": Version of the Elasticsearch domain
+* [`elasticsearch_version`]: String(optional, \"6.0\": Version of the Elasticsearch domain
 * [`options_rest_action_multi_allow_explicit_index`]: Bool(optional, true): Sets the `rest.action.multi.allow_explicit_index` advanced option. If you want to configure access to domain sub-resources, such as specific indices, you must set this property to "false". Setting this property to "false" prevents users from bypassing access control for sub-resources
 * [`options_indices_fielddata_cache_size`]: String(optional, \"unbounded\"): Sets the `indices.fielddata.cache.size` advanced option. Specifies the percentage of heap space that is allocated to fielddata
 * [`options_indices_query_bool_max_clause_count`]: Int(optional, 1024): Sets the `indices.query.bool.max_clause_count` advanced option. Specifies the maximum number of allowed boolean clauses in a query

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 
 * [`project`]: String(required): Project name
 * [`environment`]: String(required): Environment name
-* [`name`]: String(optional, \"es\"): Name to use for the Elasticsearch domain
-* [`elasticsearch_version`]: String(optional, \"6.0\": Version of the Elasticsearch domain
-* [`options_rest_action_multi_allow_explicit_index`]: Bool(optional, true): Sets the `rest.action.multi.allow_explicit_index` advanced option. If you want to configure access to domain sub-resources, such as specific indices, you must set this property to "false". Setting this property to "false" prevents users from bypassing access control for sub-resources
-* [`options_indices_fielddata_cache_size`]: String(optional, \"unbounded\"): Sets the `indices.fielddata.cache.size` advanced option. Specifies the percentage of heap space that is allocated to fielddata
-* [`options_indices_query_bool_max_clause_count`]: Int(optional, 1024): Sets the `indices.query.bool.max_clause_count` advanced option. Specifies the maximum number of allowed boolean clauses in a query
+* [`name`]: String(optional, "es"): Name to use for the Elasticsearch domain
+* [`elasticsearch_version`]: String(optional, "6.0": Version of the Elasticsearch domain
+* [`options_rest_action_multi_allow_explicit_index`]: String(optional, "true"): Sets the `rest.action.multi.allow_explicit_index` advanced option (must be string, not bool!). If you want to configure access to domain sub-resources, such as specific indices, you must set this property to "false". Setting this property to "false" prevents users from bypassing access control for sub-resources
+* [`options_indices_fielddata_cache_size`]: String(optional, ""): Sets the `indices.fielddata.cache.size` advanced option. Specifies the percentage of heap space that is allocated to fielddata
+* [`options_indices_query_bool_max_clause_count`]: String(optional, "1024"): Sets the `indices.query.bool.max_clause_count` advanced option. Specifies the maximum number of allowed boolean clauses in a query
 * [`logging_enabled`]: Bool(optional, false): Whether to enable Elasticsearch slow logs in Cloudwatch
 * [`logging_retention`]: Int(optional, 30): How many days to retain Elasticsearch logs in Cloudwatch
 * [`instance_count`]: Int(optional, 1): Size of the Elasticsearch domain
@@ -20,9 +20,9 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`dedicated_master_enabled`]: Bool(optional, false): Whether dedicated master nodes are enabled for the domain
 * [`dedicated_master_type`]: String(optional, t2.small.elasticsearch): Instance type of the dedicated master nodes in the domain
 * [`dedicated_master_count`]: Int(optional, 1): Number of dedicated master nodes in the domain
-* [`volume_type`]: String(optional, \"gp2\"): EBS volume type to use for the Elasticsearch domain
+* [`volume_type`]: String(optional, "gp2"): EBS volume type to use for the Elasticsearch domain
 * [`volume_size`]: Int(required): EBS volume size (in GB) to use for the Elasticsearch domain
-* [`volume_iops`]: Int(required if volume_type=\"io1\"): Amount of provisioned IOPS for the EBS volume
+* [`volume_iops`]: Int(required if volume_type="io1"): Amount of provisioned IOPS for the EBS volume
 * [`vpc_id`]: String(required*): VPC ID where to deploy the Elasticsearch domain. If set, you also need to specify `subnet_ids`. If not set, the module creates a public domain
 * [`subnet_ids`]: List(required*): Subnet IDs for the VPC enabled Elasticsearch domain endpoints to be created in"
 * [`security_group_ids`]: List(optional): Extra security group IDs to attach to the Elasticsearch domain. Note: a default SG is already created and exposed via outputs
@@ -30,7 +30,7 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`snapshot_bucket_enabled`]: Bool(optional, false): Whether to create a bucket for custom Elasticsearch backups (other than the default daily one)
 * [`tags`]: Map(optional, {}): Optional tags
 
-**(*)** If the `vpc_id` and `subnet_ids` are not specified, this module will create a public Elasticsearch domain. 
+**(*)** If the `vpc_id` and `subnet_ids` are not specified, this module will create a public Elasticsearch domain.
 
 ### Outputs
 
@@ -57,11 +57,6 @@ module "elasticsearch" {
   vpc_id                   = "${data.terraform_remote_state.static.vpc_id}"
   subnet_ids               = ["${slice(data.terraform_remote_state.static.db_subnets,0,var.es_instance_count)}"]
   dedicated_master_enabled = false
-
-  advanced_options {
-    "indices.fielddata.cache.size"           = ""
-    "rest.action.multi.allow_explicit_index" = "true"
-  }
 }
 
 resource "aws_elasticsearch_domain_policy" "es_policy" {

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`project`]: String(required): Project name
 * [`environment`]: String(required): Environment name
 * [`name`]: String(optional, \"es\"): Name to use for the Elasticsearch domain
-* [`version`]: String(optional, \"5.5\": Version of the Elasticsearch domain
-* [`advanced_options`]: Map(optional, {}): An Elasticsearch advanced_options block, which consists of Elasticsearch configuration options as key-value pairs
+* [`version`]: String(optional, \"6.0\": Version of the Elasticsearch domain
 * [`logging_enabled`]: Bool(optional, false): Whether to enable Elasticsearch slow logs in Cloudwatch
 * [`logging_retention`]: Int(optional, 30): How many days to retain Elasticsearch logs in Cloudwatch
 * [`instance_count`]: Int(optional, 1): Size of the Elasticsearch domain

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`environment`]: String(required): Environment name
 * [`name`]: String(optional, \"es\"): Name to use for the Elasticsearch domain
 * [`version`]: String(optional, \"6.0\": Version of the Elasticsearch domain
+* [`options_rest_action_multi_allow_explicit_index`]: Bool(optional, true): Sets the `rest.action.multi.allow_explicit_index` advanced option. If you want to configure access to domain sub-resources, such as specific indices, you must set this property to "false". Setting this property to "false" prevents users from bypassing access control for sub-resources
+* [`options_indices_fielddata_cache_size`]: String(optional, \"unbounded\"): Sets the `indices.fielddata.cache.size` advanced option. Specifies the percentage of heap space that is allocated to fielddata
+* [`options_indices_query_bool_max_clause_count`]: Int(optional, 1024): Sets the `indices.query.bool.max_clause_count` advanced option. Specifies the maximum number of allowed boolean clauses in a query
 * [`logging_enabled`]: Bool(optional, false): Whether to enable Elasticsearch slow logs in Cloudwatch
 * [`logging_retention`]: Int(optional, 30): How many days to retain Elasticsearch logs in Cloudwatch
 * [`instance_count`]: Int(optional, 1): Size of the Elasticsearch domain

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ locals {
 resource "aws_elasticsearch_domain" "es" {
   count                 = "${local.vpc_enabled ? 1 : 0}"
   domain_name           = "${var.project}-${var.environment}-${var.name}"
-  elasticsearch_version = "${var.version}"
+  elasticsearch_version = "${var.elasticsearch_version}"
   cluster_config        = ["${local.cluster_config}"]
   ebs_options           = ["${local.ebs_options}"]
   snapshot_options      = ["${local.snapshot_options}"]
@@ -69,7 +69,7 @@ resource "aws_elasticsearch_domain" "es" {
 resource "aws_elasticsearch_domain" "public_es" {
   count                 = "${local.vpc_enabled ? 0 : 1}"
   domain_name           = "${var.project}-${var.environment}-${var.name}"
-  elasticsearch_version = "${var.version}"
+  elasticsearch_version = "${var.elasticsearch_version}"
   cluster_config        = ["${local.cluster_config}"]
   ebs_options           = ["${local.ebs_options}"]
   snapshot_options      = ["${local.snapshot_options}"]

--- a/main.tf
+++ b/main.tf
@@ -37,11 +37,16 @@ resource "aws_elasticsearch_domain" "es" {
   count                 = "${local.vpc_enabled ? 1 : 0}"
   domain_name           = "${var.project}-${var.environment}-${var.name}"
   elasticsearch_version = "${var.version}"
-  advanced_options      = "${var.advanced_options}"
   cluster_config        = ["${local.cluster_config}"]
   ebs_options           = ["${local.ebs_options}"]
   snapshot_options      = ["${local.snapshot_options}"]
   tags                  = "${local.tags}"
+
+  advanced_options {
+    "rest.action.multi.allow_explicit_index" = "${var.options_rest_action_multi_allow_explicit_index}"
+    "indices.fielddata.cache.size"           = "${var.options_indices_fielddata_cache_size}"
+    "indices.query.bool.max_clause_count"    = "${var.options_indices_query_bool_max_clause_count}"
+  }
 
   log_publishing_options {
     enabled                  = "${var.logging_enabled}"
@@ -65,11 +70,16 @@ resource "aws_elasticsearch_domain" "public_es" {
   count                 = "${local.vpc_enabled ? 0 : 1}"
   domain_name           = "${var.project}-${var.environment}-${var.name}"
   elasticsearch_version = "${var.version}"
-  advanced_options      = "${var.advanced_options}"
   cluster_config        = ["${local.cluster_config}"]
   ebs_options           = ["${local.ebs_options}"]
   snapshot_options      = ["${local.snapshot_options}"]
   tags                  = "${local.tags}"
+
+  advanced_options {
+    "rest.action.multi.allow_explicit_index" = "${var.options_rest_action_multi_allow_explicit_index}"
+    "indices.fielddata.cache.size"           = "${var.options_indices_fielddata_cache_size}"
+    "indices.query.bool.max_clause_count"    = "${var.options_indices_query_bool_max_clause_count}"
+  }
 
   log_publishing_options {
     enabled                  = "${var.logging_enabled}"

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "name" {
   description = "String(optional, \"es\"): Name to use for the Elasticsearch domain"
 }
 
-variable "version" {
+variable "elasticsearch_version" {
   description = "String(optional, \"6.0\": Version of the Elasticsearch domain"
   default     = "6.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,14 +11,8 @@ variable "name" {
 }
 
 variable "version" {
-  description = "String(optional, \"5.5\": Version of the Elasticsearch domain"
-  default     = "5.5"
-}
-
-variable "advanced_options" {
-  description = "Map(optional, {}): An Elasticsearch advanced_options block, which consists of Elasticsearch configuration options as key-value pairs"
-  type        = "map"
-  default     = {}
+  description = "String(optional, \"6.0\": Version of the Elasticsearch domain"
+  default     = "6.0"
 }
 
 variable "logging_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,18 +16,21 @@ variable "elasticsearch_version" {
 }
 
 variable "options_rest_action_multi_allow_explicit_index" {
-  description = "Bool(optional, true): Sets the `rest.action.multi.allow_explicit_index` advanced option. If you want to configure access to domain sub-resources, such as specific indices, you must set this property to `false`. Setting this property to `false` prevents users from bypassing access control for sub-resources"
-  default     = true
+  description = "Bool(optional, \"true\"): Sets the `rest.action.multi.allow_explicit_index` advanced option (must be string, not bool!). If you want to configure access to domain sub-resources, such as specific indices, you must set this property to \"false\". Setting this property to \"false\" prevents users from bypassing access control for sub-resources"
+  type        = "string"
+  default     = "true"
 }
 
 variable "options_indices_fielddata_cache_size" {
-  description = "String(optional, \"unbounded\"): Sets the `indices.fielddata.cache.size` advanced option. Specifies the percentage of heap space that is allocated to fielddata"
-  default     = "unbounded"
+  description = "String(optional, \"\"): Sets the `indices.fielddata.cache.size` advanced option. Specifies the percentage of heap space that is allocated to fielddata"
+  type        = "string"
+  default     = ""
 }
 
 variable "options_indices_query_bool_max_clause_count" {
-  description = "Int(optional, 1024): Sets the `indices.query.bool.max_clause_count` advanced option. Specifies the maximum number of allowed boolean clauses in a query"
-  default     = 1024
+  description = "String(optional, \"1024\"): Sets the `indices.query.bool.max_clause_count` advanced option. Specifies the maximum number of allowed boolean clauses in a query"
+  type        = "string"
+  default     = "1024"
 }
 
 variable "logging_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,21 @@ variable "version" {
   default     = "6.0"
 }
 
+variable "options_rest_action_multi_allow_explicit_index" {
+  description = "Bool(optional, true): Sets the `rest.action.multi.allow_explicit_index` advanced option. If you want to configure access to domain sub-resources, such as specific indices, you must set this property to `false`. Setting this property to `false` prevents users from bypassing access control for sub-resources"
+  default     = true
+}
+
+variable "options_indices_fielddata_cache_size" {
+  description = "String(optional, \"unbounded\"): Sets the `indices.fielddata.cache.size` advanced option. Specifies the percentage of heap space that is allocated to fielddata"
+  default     = "unbounded"
+}
+
+variable "options_indices_query_bool_max_clause_count" {
+  description = "Int(optional, 1024): Sets the `indices.query.bool.max_clause_count` advanced option. Specifies the maximum number of allowed boolean clauses in a query"
+  default     = 1024
+}
+
 variable "logging_enabled" {
   description = "Bool(optional, false): Whether to enable Elasticsearch slow logs in Cloudwatch"
   default     = false


### PR DESCRIPTION
Fix the constant change triggered when running terraform for advanced_options by explicitely setting them with their AWS defaults.

Also bump the default ES version to 6.0.

Related to issue https://github.com/skyscrapers/persistence/issues/30