### PR TITLE
Generate Helm values for monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`snapshot_start_hour`]: Int(optional, 3): Hour during which an automated daily snapshot is taken of the Elasticsearch indices
 * [`snapshot_bucket_enabled`]: Bool(optional, false): Whether to create a bucket for custom Elasticsearch backups (other than the default daily one)
 * [`tags`]: Map(optional, {}): Optional tags
+* [`prometheus_labels`]: Map(optional, {}): Prometheus MatchLabel labels for generating the elasticsearch-monitoring Helm chart. When empty, no values file is generated
 
 **(*)** If the `vpc_id` and `subnet_ids` are not specified, this module will create a public Elasticsearch domain.
 
@@ -90,3 +91,7 @@ It's possible to create a custom backup schedule by using the normal Elasticsear
 ## Logging
 
 This module by default creates Cloudwatch Log Groups & IAM permissions for ElasticSearch slow logging, but we don't enable these logs by default. You can control logging behavior via the `logging_enabled` and `logging_retention` parameters. When enabling this, make sure you also enable this on Elasticsearch side, following the [AWS documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-slow-logs).
+
+## Monitoring
+
+This module generates a Helm values file which can be used for the [`elasticsearch/monitoring`](https://github.com/skyscrapers/charts/elasticsearch-monitoring) chart.

--- a/helm-values.tf
+++ b/helm-values.tf
@@ -1,0 +1,29 @@
+locals {
+  elasticsearch_endpoint = "https://${element(concat(aws_elasticsearch_domain.es.*.endpoint, aws_elasticsearch_domain.public_es.*.endpoint), 0)}"
+}
+
+data "template_file" "helm_values" {
+  count    = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
+  template = "${file("${path.module}/templates/helm-values.tpl.yaml")}"
+
+  vars {
+    elasticsearch_endpoint = "${local.elasticsearch_endpoint}"
+    prometheus_labels      = "${indent(4, join("\n", data.template_file.prometheus_kv_mapping.*.rendered))}"
+  }
+}
+
+data "template_file" "prometheus_kv_mapping" {
+  count    = "${length(var.prometheus_labels)}"
+  template = "$${key}: $${value}"
+
+  vars {
+    key   = "${element(keys(var.prometheus_labels), count.index)}"
+    value = "${element(values(var.prometheus_labels), count.index)}"
+  }
+}
+
+resource "local_file" "helm_values_file" {
+  count    = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
+  content  = "${data.template_file.helm_values.rendered}"
+  filename = "${path.cwd}/helm-values.yaml"
+}

--- a/templates/helm-values.tpl.yaml
+++ b/templates/helm-values.tpl.yaml
@@ -1,0 +1,8 @@
+## Prometheus MatchLabel selectors
+prometheus:
+  labels:
+    ${prometheus_labels}
+
+elasticsearch-exporter:
+  es:
+    uri: ${elasticsearch_endpoint}

--- a/variables.tf
+++ b/variables.tf
@@ -119,3 +119,8 @@ variable "tags" {
   type        = "map"
   default     = {}
 }
+
+variable "prometheus_labels" {
+  description = "Map(optional, {}): Prometheus MatchLabel labels for generating the elasticsearch-monitoring Helm chart. When empty, no values file is generated"
+  default = {}
+}


### PR DESCRIPTION
Adds a file resource for creating Helm values used in https://github.com/skyscrapers/charts/elasticsearch-monitoring.

https://github.com/skyscrapers/persistence/issues/29