### PR TITLE
Enable encrypt_at_rest on supported instances, unless overridden skyscrapers/persistence#36

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`snapshot_bucket_enabled`]: Bool(optional, false): Whether to create a bucket for custom Elasticsearch backups (other than the default daily one)
 * [`tags`]: Map(optional, {}): Optional tags
 * [`prometheus_labels`]: Map(optional, {}): Prometheus MatchLabel labels for generating the elasticsearch-monitoring Helm chart. When empty, no values file is generated
+* [`disable_encrypt_at_rest`]: Bool(optional, false): Whether to force-disable encryption at rest, overriding the default to enable encryption if it is supported by the chosen `instance_type`. You can set this to `true` if you want to scale up the instance_type on an existing Amazon ES domain with encryption disabled.
 
 **(*)** If the `vpc_id` and `subnet_ids` are not specified, this module will create a public Elasticsearch domain.
 
@@ -48,7 +49,7 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 
 ```terraform
 module "elasticsearch" {
-  source                   = "github.com/skyscrapers/terraform-awselasticsearch?ref=0.1"
+  source                   = "github.com/skyscrapers/terraform-awselasticsearch?ref=2.0"
   name                     = "es"
   project                  = "${var.project}"
   environment              = "${terraform.workspace}"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`snapshot_bucket_enabled`]: Bool(optional, false): Whether to create a bucket for custom Elasticsearch backups (other than the default daily one)
 * [`tags`]: Map(optional, {}): Optional tags
 * [`prometheus_labels`]: Map(optional, {}): Prometheus MatchLabel labels for generating the elasticsearch-monitoring Helm chart. When empty, no values file is generated
-* [`disable_encrypt_at_rest`]: Bool(optional, false): Whether to force-disable encryption at rest, overriding the default to enable encryption if it is supported by the chosen `instance_type`. You can set this to `true` if you want to scale up the instance_type on an existing Amazon ES domain with encryption disabled.
+* [`disable_encrypt_at_rest`]: Bool(optional, false): Whether to force-disable encryption at rest, overriding the default to enable encryption if it is supported by the chosen `instance_type`. If you want to keep encryption disabled on an `instance_type` that is compatible with encryption you need to set this parameter to `true`. This is especially important for existing Amazon ES clusters, since enabling/disabling encryption at rest will destroy your cluster!
 
 **(*)** If the `vpc_id` and `subnet_ids` are not specified, this module will create a public Elasticsearch domain.
 

--- a/ebs_encryption_list.tf
+++ b/ebs_encryption_list.tf
@@ -1,0 +1,26 @@
+# List all instances which support encryption at rest
+# https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-instance-types.html
+variable "ebs_encryption_list" {
+  type = "list"
+
+  default = [
+    "m4.large.elasticsearch",
+    "m4.xlarge.elasticsearch",
+    "m4.2xlarge.elasticsearch",
+    "m4.4xlarge.elasticsearch",
+    "m4.10xlarge.elasticsearch",
+    "c4.large.elasticsearch",
+    "c4.xlarge.elasticsearch",
+    "c4.2xlarge.elasticsearch",
+    "c4.4xlarge.elasticsearch",
+    "c4.8xlarge.elasticsearch",
+    "r4.large.elasticsearch",
+    "r4.xlarge.elasticsearch",
+    "r4.2xlarge.elasticsearch",
+    "r4.4xlarge.elasticsearch",
+    "r4.8xlarge.elasticsearch",
+    "r4.16xlarge.elasticsearch",
+    "i2.xlarge.elasticsearch",
+    "i2.2xlarge.elasticsearch",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,10 @@ resource "aws_elasticsearch_domain" "es" {
     "indices.query.bool.max_clause_count"    = "${var.options_indices_query_bool_max_clause_count}"
   }
 
+  encrypt_at_rest {
+    enabled = "${var.disable_encrypt_at_rest ? false : contains(var.ebs_encryption_list, var.instance_type)}"
+  }
+
   log_publishing_options {
     enabled                  = "${var.logging_enabled}"
     log_type                 = "INDEX_SLOW_LOGS"
@@ -79,6 +83,10 @@ resource "aws_elasticsearch_domain" "public_es" {
     "rest.action.multi.allow_explicit_index" = "${var.options_rest_action_multi_allow_explicit_index}"
     "indices.fielddata.cache.size"           = "${var.options_indices_fielddata_cache_size}"
     "indices.query.bool.max_clause_count"    = "${var.options_indices_query_bool_max_clause_count}"
+  }
+
+  encrypt_at_rest {
+    enabled = "${var.disable_encrypt_at_rest ? false : contains(var.ebs_encryption_list, var.instance_type)}"
   }
 
   log_publishing_options {

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,6 @@ variable "prometheus_labels" {
 }
 
 variable "disable_encrypt_at_rest" {
-  description = "Bool(optional, false): Whether to force-disable encryption at rest, overriding the default to enable encryption if it is supported by the chosen `instance_type`. You can set this to `true` if you want to scale up the instance_type on an existing Amazon ES domain with encryption disabled."
+  description = "Bool(optional, false): Whether to force-disable encryption at rest, overriding the default to enable encryption if it is supported by the chosen `instance_type`. If you want to keep encryption disabled on an `instance_type` that is compatible with encryption you need to set this parameter to `true`. This is especially important for existing Amazon ES clusters, since enabling/disabling encryption at rest will destroy your cluster!"
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -124,3 +124,8 @@ variable "prometheus_labels" {
   description = "Map(optional, {}): Prometheus MatchLabel labels for generating the elasticsearch-monitoring Helm chart. When empty, no values file is generated"
   default = {}
 }
+
+variable "disable_encrypt_at_rest" {
+  description = "Bool(optional, false): Whether to force-disable encryption at rest, overriding the default to enable encryption if it is supported by the chosen `instance_type`. You can set this to `true` if you want to scale up the instance_type on an existing Amazon ES domain with encryption disabled."
+  default     = false
+}


### PR DESCRIPTION
- Adds a list of instances which support encrypt_at_rest to enable encryption by default if possible.
- Adds the possibility to override this behavior and forcefully disable encrypt_at_rest. This is necessary since the `encrypt_at_rest` Amazon ES setting can't be changed for existing ES domains.