### PR TITLE
Add role to use with Cloudwatch exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`snapshot_bucket_enabled`]: Bool(optional, false): Whether to create a bucket for custom Elasticsearch backups (other than the default daily one)
 * [`tags`]: Map(optional, {}): Optional tags
 * [`prometheus_labels`]: Map(optional, {}): Prometheus MatchLabel labels for generating the elasticsearch-monitoring Helm chart. When empty, no values file is generated
+* [`cloudwatch_exporter_allowed_assume_role`]: String(required if prometheus_labels is specified): Instance profile role which is allowed to assume the Cloudwatch exporter role (eg. via kube2iam)
+* [`cloudwatch_exporter_role_path`]: String(optional, /kube2iam/): Path where the Cloudwatch exporter IAM role will be created
 * [`disable_encrypt_at_rest`]: Bool(optional, false): Whether to force-disable encryption at rest, overriding the default to enable encryption if it is supported by the chosen `instance_type`. If you want to keep encryption disabled on an `instance_type` that is compatible with encryption you need to set this parameter to `true`. This is especially important for existing Amazon ES clusters, since enabling/disabling encryption at rest will destroy your cluster!
 
 **(*)** If the `vpc_id` and `subnet_ids` are not specified, this module will create a public Elasticsearch domain.

--- a/helm-values.tf
+++ b/helm-values.tf
@@ -7,8 +7,9 @@ data "template_file" "helm_values" {
   template = "${file("${path.module}/templates/helm-values.tpl.yaml")}"
 
   vars {
-    elasticsearch_endpoint = "${local.elasticsearch_endpoint}"
-    prometheus_labels      = "${indent(4, join("\n", data.template_file.prometheus_kv_mapping.*.rendered))}"
+    elasticsearch_endpoint   = "${local.elasticsearch_endpoint}"
+    prometheus_labels        = "${indent(4, join("\n", data.template_file.prometheus_kv_mapping.*.rendered))}"
+    cloudwatch_exporter_role = "${aws_iam_role.cloudwatch_exporter.arn}"
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -73,3 +73,54 @@ resource "aws_iam_role_policy_attachment" "snapshot_policy_attachment" {
   role       = "${aws_iam_role.role.id}"
   policy_arn = "${aws_iam_policy.snapshot_policy.arn}"
 }
+
+## The following role can be used for the prometheus-cloudwatch-exporter
+
+data "aws_iam_policy_document" "cloudwatch_exporter_assume" {
+  count    = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.cloudwatch_exporter_allowed_assume_role}"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch_exporter" {
+  count    = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "cloudwatch_exporter" {
+  count              = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
+  name               = "cloudwatch_es_${var.project}_${var.environment}"
+  path               = "${var.cloudwatch_exporter_role_path}"
+  assume_role_policy = "${data.aws_iam_policy_document.cloudwatch_exporter_assume.json}"
+}
+
+resource "aws_iam_policy_attachment" "cloudwatch_exporter" {
+  count      = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
+  name       = "cloudwatch_es_${var.project}_${var.environment}"
+  roles      = ["${aws_iam_role.cloudwatch_exporter.name}"]
+  policy_arn = "${aws_iam_policy.cloudwatch_exporter.arn}"
+}
+
+resource "aws_iam_policy" "cloudwatch_exporter" {
+  count  = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
+  name   = "cloudwatch_es_${var.project}_${var.environment}"
+  policy = "${data.aws_iam_policy_document.cloudwatch_exporter.json}"
+}

--- a/iam.tf
+++ b/iam.tf
@@ -112,15 +112,14 @@ resource "aws_iam_role" "cloudwatch_exporter" {
   assume_role_policy = "${data.aws_iam_policy_document.cloudwatch_exporter_assume.json}"
 }
 
-resource "aws_iam_policy_attachment" "cloudwatch_exporter" {
-  count      = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
-  name       = "cloudwatch_es_${var.project}_${var.environment}"
-  roles      = ["${aws_iam_role.cloudwatch_exporter.name}"]
-  policy_arn = "${aws_iam_policy.cloudwatch_exporter.arn}"
-}
-
 resource "aws_iam_policy" "cloudwatch_exporter" {
   count  = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
   name   = "cloudwatch_es_${var.project}_${var.environment}"
   policy = "${data.aws_iam_policy_document.cloudwatch_exporter.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_exporter" {
+  count      = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
+  role       = "${aws_iam_role.cloudwatch_exporter.name}"
+  policy_arn = "${aws_iam_policy.cloudwatch_exporter.arn}"
 }

--- a/templates/helm-values.tpl.yaml
+++ b/templates/helm-values.tpl.yaml
@@ -3,6 +3,12 @@ prometheus:
   labels:
     ${prometheus_labels}
 
+amazonService: true
+
 elasticsearch-exporter:
   es:
     uri: ${elasticsearch_endpoint}
+
+prometheus-cloudwatch-exporter:
+  aws:
+    role: "${cloudwatch_exporter_role}"

--- a/templates/helm-values.tpl.yaml
+++ b/templates/helm-values.tpl.yaml
@@ -3,7 +3,8 @@ prometheus:
   labels:
     ${prometheus_labels}
 
-amazonService: true
+amazonService:
+  enabled: true
 
 elasticsearch-exporter:
   es:

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,16 @@ variable "prometheus_labels" {
   default = {}
 }
 
+variable "cloudwatch_exporter_allowed_assume_role" {
+  description = "String(required if prometheus_labels is specified): Instance profile role which is allowed to assume the Cloudwatch exporter role (eg. via kube2iam)"
+  default = ""
+}
+
+variable "cloudwatch_exporter_role_path" {
+  description = "String(optional, /kube2iam/): Path where the Cloudwatch exporter IAM role will be created"
+  default = "/kube2iam/"
+}
+
 variable "disable_encrypt_at_rest" {
   description = "Bool(optional, false): Whether to force-disable encryption at rest, overriding the default to enable encryption if it is supported by the chosen `instance_type`. If you want to keep encryption disabled on an `instance_type` that is compatible with encryption you need to set this parameter to `true`. This is especially important for existing Amazon ES clusters, since enabling/disabling encryption at rest will destroy your cluster!"
   default     = false


### PR DESCRIPTION
When Prometheus is enabled, creates a role to use in conjunction with the [Cloudwatch Exporter](https://github.com/prometheus/cloudwatch_exporter). This also adds the required values for https://github.com/skyscrapers/charts/pull/40

Related issue: https://github.com/skyscrapers/engineering/issues/102

Tested in SkyscrapersTest

```
 <= module.logs.data.template_file.helm_values
      id:                    <computed>
      rendered:              <computed>
      template:              "## Prometheus MatchLabel selectors\nprometheus:\n  labels:\n    ${prometheus_labels}\n\namazonService: true\n\nelasticsearch-exporter:\n  es:\n    uri: ${elasticsearch_endpoint}\n\nprometheus-cloudwatch-exporter:\n  aws:\n    role: ${cloudwatch_exporter_role}\n"
      vars.%:                <computed>

  + module.logs.aws_iam_policy.cloudwatch_exporter
      id:                    <computed>
      arn:                   <computed>
      name:                  "cloudwatch_es_skyscrapers_test"
      path:                  "/"
      policy:                "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"cloudwatch:ListMetrics\",\n        \"cloudwatch:GetMetricStatistics\"\n      ],\n      \"Resource\": \"*\"\n    }\n  ]\n}"

  + module.logs.aws_iam_policy_attachment.cloudwatch_exporter
      id:                    <computed>
      name:                  "cloudwatch_es_skyscrapers_test"
      policy_arn:            "${aws_iam_policy.cloudwatch_exporter.arn}"
      roles.#:               "1"
      roles.130083363:       "cloudwatch_es_skyscrapers_test"

  + module.logs.aws_iam_role.cloudwatch_exporter
      id:                    <computed>
      arn:                   <computed>
      assume_role_policy:    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::847239549153:role/nodes.test.skyscrape.rs\"\n      }\n    }\n  ]\n}"
      create_date:           <computed>
      force_detach_policies: "false"
      max_session_duration:  "3600"
      name:                  "cloudwatch_es_skyscrapers_test"
      path:                  "/kube2iam/"
      unique_id:             <computed>

  + module.logs.local_file.helm_values_file
      id:                    <computed>
      content:               "${data.template_file.helm_values.rendered}"
      filename:              "/home/philip/skyscrapers/skyscrapers-terraform/stacks/elasticsearch/helm-values.yaml"
```