### PR TITLE
Filter on DomainName for cloudwatch exporter

### DIFF
--- a/helm-values.tf
+++ b/helm-values.tf
@@ -2,6 +2,8 @@ locals {
   elasticsearch_endpoint = "https://${element(concat(aws_elasticsearch_domain.es.*.endpoint, aws_elasticsearch_domain.public_es.*.endpoint), 0)}"
 }
 
+data "aws_region" "current" {}
+
 data "template_file" "helm_values" {
   count    = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
   template = "${file("${path.module}/templates/helm-values.tpl.yaml")}"
@@ -10,6 +12,8 @@ data "template_file" "helm_values" {
     elasticsearch_endpoint   = "${local.elasticsearch_endpoint}"
     prometheus_labels        = "${indent(4, join("\n", data.template_file.prometheus_kv_mapping.*.rendered))}"
     cloudwatch_exporter_role = "${aws_iam_role.cloudwatch_exporter.arn}"
+    region                   = "${data.aws_region.current.name}"
+    elasticsearch_domain     = "${element(concat(aws_elasticsearch_domain.es.*.domain_name, aws_elasticsearch_domain.public_es.*.domain_name), 0)}"
   }
 }
 

--- a/sg.tf
+++ b/sg.tf
@@ -3,6 +3,5 @@ resource "aws_security_group" "sg" {
   name        = "${var.project}-${var.environment}-${var.name}"
   description = "Security group for the ${var.project} Elasticsearch domain"
   vpc_id      = "${var.vpc_id}"
-
-  tags = "${local.tags}"
+  tags        = "${local.tags}"
 }

--- a/templates/helm-values.tpl.yaml
+++ b/templates/helm-values.tpl.yaml
@@ -13,3 +13,14 @@ elasticsearch-exporter:
 prometheus-cloudwatch-exporter:
   aws:
     role: "${cloudwatch_exporter_role}"
+  config: |-
+    region: ${region}
+    period_seconds: 60
+    set_timestamp: false
+    metrics:
+    - aws_namespace: AWS/ES
+      aws_metric_name: FreeStorageSpace
+      aws_dimensions: [ClientId, DomainName]
+      aws_dimension_select:
+        DomainName: [${elasticsearch_domain}]
+      aws_statistics: [Minimum, Maximum, Average, Sum]


### PR DESCRIPTION
Generate the full prometheus-cloudwatch-exporter config to add a Dimension Selector. This change is required to only gather metrics for the Elasticsearch Domain we're monitoring.

This issue popped up while rolling out the previous changes acros our environments, resulting in both staging & production metrics being gathered in eg. the staging Prometheus.

Tested on our SkyscrapersTest environment and a customer's staging env.

Related issue: https://github.com/skyscrapers/engineering/issues/102