### PR TITLE
Bump default ES version to 6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`project`]: String(required): Project name
 * [`environment`]: String(required): Environment name
 * [`name`]: String(optional, "es"): Name to use for the Elasticsearch domain
-* [`elasticsearch_version`]: String(optional, "6.0": Version of the Elasticsearch domain
+* [`elasticsearch_version`]: String(optional, "6.3": Version of the Elasticsearch domain
 * [`options_rest_action_multi_allow_explicit_index`]: String(optional, "true"): Sets the `rest.action.multi.allow_explicit_index` advanced option (must be string, not bool!). If you want to configure access to domain sub-resources, such as specific indices, you must set this property to "false". Setting this property to "false" prevents users from bypassing access control for sub-resources
 * [`options_indices_fielddata_cache_size`]: String(optional, ""): Sets the `indices.fielddata.cache.size` advanced option. Specifies the percentage of heap space that is allocated to fielddata
 * [`options_indices_query_bool_max_clause_count`]: String(optional, "1024"): Sets the `indices.query.bool.max_clause_count` advanced option. Specifies the maximum number of allowed boolean clauses in a query

--- a/variables.tf
+++ b/variables.tf
@@ -11,8 +11,8 @@ variable "name" {
 }
 
 variable "elasticsearch_version" {
-  description = "String(optional, \"6.0\": Version of the Elasticsearch domain"
-  default     = "6.0"
+  description = "String(optional, \"6.3\": Version of the Elasticsearch domain"
+  default     = "6.3"
 }
 
 variable "options_rest_action_multi_allow_explicit_index" {


### PR DESCRIPTION
AWS offers 6.3 now, which fixes some bugs we've encountered on one of our customer's clusters.

Upgrade tested on both our Test account and the customer.