### PR TITLE
Ephemeral storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 * [`zone_awareness_enabled`]: Bool(optional, false): Whether to enable zone_awareness or not
 * [`dedicated_master_type`]: String(optional, t2.small.elasticsearch): Instance type of the dedicated master nodes in the domain
 * [`dedicated_master_count`]: Int(optional, 1): Number of dedicated master nodes in the domain
-* [`volume_type`]: String(optional, "gp2"): EBS volume type to use for the Elasticsearch domain
+* [`volume_type`]: String(optional, "gp2"): EBS volume type to use for the Elasticsearch domain. If you use an instance type which supports ephemeral storage, these options will be ignored.
 * [`volume_size`]: Int(required): EBS volume size (in GB) to use for the Elasticsearch domain
 * [`volume_iops`]: Int(required if volume_type="io1"): Amount of provisioned IOPS for the EBS volume
 * [`vpc_id`]: String(required*): VPC ID where to deploy the Elasticsearch domain. If set, you also need to specify `subnet_ids`. If not set, the module creates a public domain

--- a/encryption_list.tf
+++ b/encryption_list.tf
@@ -22,6 +22,7 @@ variable "encryption_list" {
     "r4.16xlarge.elasticsearch",
     "i2.xlarge.elasticsearch",
     "i2.2xlarge.elasticsearch",
+    "i3.large.elasticsearch",
     "i3.xlarge.elasticsearch",
     "i3.2xlarge.elasticsearch",
     "i3.4xlarge.elasticsearch",

--- a/encryption_list.tf
+++ b/encryption_list.tf
@@ -1,6 +1,6 @@
 # List all instances which support encryption at rest
 # https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-instance-types.html
-variable "ebs_encryption_list" {
+variable "encryption_list" {
   type = "list"
 
   default = [
@@ -22,5 +22,10 @@ variable "ebs_encryption_list" {
     "r4.16xlarge.elasticsearch",
     "i2.xlarge.elasticsearch",
     "i2.2xlarge.elasticsearch",
+    "i3.xlarge.elasticsearch",
+    "i3.2xlarge.elasticsearch",
+    "i3.4xlarge.elasticsearch",
+    "i3.8xlarge.elasticsearch",
+    "i3.16xlarge.elasticsearch",
   ]
 }

--- a/ephemeral_list.tf
+++ b/ephemeral_list.tf
@@ -1,0 +1,27 @@
+# List all instances which support encryption at rest
+# https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-instance-types.html
+
+# m3 and r3 are supported by aws using ephemeral storage but are a lecacy instance type
+variable "ephemeral_list" {
+  type = "list"
+
+  default = [
+    "i2.xlarge.elasticsearch",
+    "i2.2xlarge.elasticsearch",
+    "i3.xlarge.elasticsearch",
+    "i3.2xlarge.elasticsearch",
+    "i3.4xlarge.elasticsearch",
+    "i3.8xlarge.elasticsearch",
+    "i3.16xlarge.elasticsearch",
+  ]
+
+  # "m3.medium.elasticsearch",
+  # "m3.large.elasticsearch",
+  # "m3.xlarge.elasticsearch",
+  # "m3.2xlarge.elasticsearch",
+  # "r3.large.elasticsearch",
+  # "r3.xlarge.elasticsearch",
+  # "r3.2xlarge.elasticsearch",
+  # "r3.4xlarge.elasticsearch",
+  # "r3.8xlarge.elasticsearch",
+}

--- a/ephemeral_list.tf
+++ b/ephemeral_list.tf
@@ -8,6 +8,7 @@ variable "ephemeral_list" {
   default = [
     "i2.xlarge.elasticsearch",
     "i2.2xlarge.elasticsearch",
+    "i3.large.elasticsearch",
     "i3.xlarge.elasticsearch",
     "i3.2xlarge.elasticsearch",
     "i3.4xlarge.elasticsearch",

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ locals {
   }
 
   ebs_options = {
-    ebs_enabled = true
+    ebs_enabled = "${contains(var.ephemeral_list, var.instance_type) ? false : true }"
     volume_type = "${var.volume_type}"
     volume_size = "${var.volume_size}"
     iops        = "${var.volume_type == "io1" ? var.volume_iops : 0}"

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "aws_elasticsearch_domain" "es" {
   }
 
   encrypt_at_rest {
-    enabled = "${var.disable_encrypt_at_rest ? false : contains(var.ebs_encryption_list, var.instance_type)}"
+    enabled = "${var.disable_encrypt_at_rest ? false : contains(var.encryption_list, var.instance_type)}"
   }
 
   log_publishing_options {
@@ -86,7 +86,7 @@ resource "aws_elasticsearch_domain" "public_es" {
   }
 
   encrypt_at_rest {
-    enabled = "${var.disable_encrypt_at_rest ? false : contains(var.ebs_encryption_list, var.instance_type)}"
+    enabled = "${var.disable_encrypt_at_rest ? false : contains(var.encryption_list, var.instance_type)}"
   }
 
   log_publishing_options {

--- a/main.tf
+++ b/main.tf
@@ -23,8 +23,8 @@ locals {
 
   ebs_options = {
     ebs_enabled = "${contains(var.ephemeral_list, var.instance_type) ? false : true }"
-    volume_type = "${var.volume_type}"
-    volume_size = "${var.volume_size}"
+    volume_type = "${contains(var.ephemeral_list, var.instance_type) ? "" : var.volume_type }"
+    volume_size = "${contains(var.ephemeral_list, var.instance_type) ? 0 : var.volume_size }"
     iops        = "${var.volume_type == "io1" ? var.volume_iops : 0}"
   }
 


### PR DESCRIPTION
for https://github.com/skyscrapers/engineering/issues/116

when an instance is added which supports ephemeral storage, it will be used instead of EBS storage.