### PR TITLE
Create the default ES service role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,10 @@ locals {
   }
 }
 
+resource "aws_iam_service_linked_role" "es" {
+  aws_service_name = "es.amazonaws.com"
+}
+
 resource "aws_elasticsearch_domain" "es" {
   count                 = "${local.vpc_enabled ? 1 : 0}"
   domain_name           = "${var.project}-${var.environment}-${var.name}"
@@ -68,6 +72,8 @@ resource "aws_elasticsearch_domain" "es" {
     security_group_ids = ["${aws_security_group.sg.id}", "${var.security_group_ids}"]
     subnet_ids         = ["${var.subnet_ids}"]
   }
+
+  depends_on = ["aws_iam_service_linked_role.es"]
 }
 
 resource "aws_elasticsearch_domain" "public_es" {


### PR DESCRIPTION
Useful for new accounts that haven't yet used ES from the AWS console. In those cases, the default service role "AWSServiceRoleForAmazonElasticsearchService" is not yet created and Terraform throws an error. This fixes that problem.