### PR TITLE
Set resource requests and limits for the es and cw exporters

### DIFF
--- a/templates/helm-values.tpl.yaml
+++ b/templates/helm-values.tpl.yaml
@@ -7,10 +7,24 @@ amazonService:
   enabled: true
 
 elasticsearch-exporter:
+  resources:
+    limits:
+      cpu: 10m
+      memory: 40Mi
+    requests:
+      cpu: 5m
+      memory: 20Mi
   es:
     uri: ${elasticsearch_endpoint}
 
 prometheus-cloudwatch-exporter:
+  resources:
+    limits:
+      cpu: 10m
+      memory: 300Mi
+    requests:
+      cpu: 5m
+      memory: 150Mi
   aws:
     role: "${cloudwatch_exporter_role}"
   config: |-


### PR DESCRIPTION
## ES exporter

Resource requests and limits were not specified previously.

- Avg. memory usage over 30 days: ~ 15 Mi
   - Set a memory request of 20Mi and limit of 40Mi
- Avg. CPU usage over 30 days: 3m (max. of 5m)
   - Set a CPU request of 5m and a limit of 10m

## CW exporter

Resource requests and limits were not specified previously.

- Avg. memory usage over 30 days: ~127 Mi (max. of ~142 Mi)
   - Set a memory request of 150Mi and limit of 300Mi
- Avg. CPU usage over 30 days: 1m (max. 7m)
   - Set a CPU request of 5m and a limit of 10m
