### PR TITLE
Add relative paths for helm value files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/README.md
+++ b/README.md
@@ -98,3 +98,5 @@ This module by default creates Cloudwatch Log Groups & IAM permissions for Elast
 ## Monitoring
 
 This module generates a Helm values file which can be used for the [`elasticsearch/monitoring`](https://github.com/skyscrapers/charts/elasticsearch-monitoring) chart.
+
+The file, `helm_values.yaml` needs to be created in the same folder as the Terraform code that is calling this module.

--- a/helm-values.tf
+++ b/helm-values.tf
@@ -10,7 +10,7 @@ data "aws_region" "current" {}
 
 data "template_file" "helm_values" {
   count    = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
-  template = "${file("${local.template_filename}")}"
+  template = "${file("${path.module}/templates/helm-values.tpl.yaml")}"
 
   vars {
     elasticsearch_endpoint   = "${local.elasticsearch_endpoint}"

--- a/helm-values.tf
+++ b/helm-values.tf
@@ -1,9 +1,5 @@
 locals {
   elasticsearch_endpoint = "https://${element(concat(aws_elasticsearch_domain.es.*.endpoint, aws_elasticsearch_domain.public_es.*.endpoint), 0)}"
-
-  template_filename = "${substr("${path.module}/templates/helm-values.tpl.yaml", length(path.cwd) + 1, -1)}"
-  // +1 for removing the "/"
-  helm_values_filename = "${substr("${path.module}/helm-values.yaml", length(path.cwd) + 1, -1)}"
 }
 
 data "aws_region" "current" {}
@@ -34,5 +30,5 @@ data "template_file" "prometheus_kv_mapping" {
 resource "local_file" "helm_values_file" {
   count    = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
   content  = "${data.template_file.helm_values.rendered}"
-  filename = "${local.helm_values_filename}"
+  filename = "helm-values.yaml"
 }

--- a/helm-values.tf
+++ b/helm-values.tf
@@ -30,5 +30,6 @@ data "template_file" "prometheus_kv_mapping" {
 resource "local_file" "helm_values_file" {
   count    = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
   content  = "${data.template_file.helm_values.rendered}"
+  # The file needs to be in the same folder as the TF code calling this module.
   filename = "helm-values.yaml"
 }

--- a/helm-values.tf
+++ b/helm-values.tf
@@ -10,7 +10,7 @@ data "aws_region" "current" {}
 
 data "template_file" "helm_values" {
   count    = "${length(var.prometheus_labels) != 0 ? 1 : 0}"
-  template = "${local.template_filename}"
+  template = "${file("${local.template_filename}")}"
 
   vars {
     elasticsearch_endpoint   = "${local.elasticsearch_endpoint}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Adds locals to make the paths relative for the Helm values template and the module's helm values files.

- Adds the PR template to this repo.

- Will run `terraform fmt` before merge.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[Update SG rule descriptions](https://github.com/teamleadercrm/skyscrapers/issues/217)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Prevents TF runs always updating the content because the path is different on each operators host, even though the content hasn't changed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with TL staging `terraform/stacks/elasticsearch` repo and this commit value instead of release value of `2.3.3`.

### Before change

```
  + module.logs.local_file.helm_values_file
      id:          <computed>
      content:     "## Prometheus MatchLabel selectors\nprometheus:\n  labels:\n    app: prometheus\n    prometheus: k8s-monitor\n    role: alert-rules\n\namazonService:\n  enabled: true\n\
nelasticsearch-exporter:\n  resources:\n    limits:\n      cpu: 10m\n      memory: 40Mi\n    requests:\n      cpu: 5m\n      memory: 20Mi\n  es:\n    uri: https://vpc-TL-staging-log
s-5pwpdhk4stpjmwwa4bpvikhoqm.eu-west-1.es.amazonaws.com\n\nprometheus-cloudwatch-exporter:\n  resources:\n    limits:\n      memory: 300Mi\n    requests:\n      cpu: 5m\n      memory: 150Mi
\n  aws:\n    role: \"arn:aws:iam::706305148424:role/kube2iam/cloudwatch_es_TL_staging\"\n  config: |-\n    region: eu-west-1\n    period_seconds: 60\n    set_timestamp: false\n
metrics:\n    - aws_namespace: AWS/ES\n      aws_metric_name: FreeStorageSpace\n      aws_dimensions: [ClientId, DomainName]\n      aws_dimension_select:\n        DomainName: [TL-st
aging-logs]\n      aws_statistics: [Minimum, Maximum, Average, Sum]\n"
      filename:    "/home/adey/skyscrapers/repos/CUSTOMERS/TL/skyscrapers/terraform/stacks/elasticsearch/helm-values.yaml"

Plan: 1 to add, 0 to change, 0 to destroy.
```

### After change

```
Terraform will perform the following actions:

  + module.logs.local_file.helm_values_file
      id:          <computed>
      content:     "## Prometheus MatchLabel selectors\nprometheus:\n  labels:\n    app: prometheus\n    prometheus: k8s-monitor\n    role: alert-rules\n\namazonService:\n  enabled: true\n\nelasticsearch-exporter:\n  resources:\n    limits:\n      cpu: 10m\n      memory: 40Mi\n    requests:\n      cpu: 5m\n      memory: 20Mi\n  es:\n    uri: https://vpc-TL-staging-logs-5pwpdhk4stpjmwwa4bpvikhoqm.eu-west-1.es.amazonaws.com\n\nprometheus-cloudwatch-exporter:\n  resources:\n    limits:\n      memory: 300Mi\n    requests:\n      cpu: 5m\n      memory: 150Mi\n  aws:\n    role: \"arn:aws:iam::706305148424:role/kube2iam/cloudwatch_es_TL_staging\"\n  config: |-\n    region: eu-west-1\n    period_seconds: 60\n    set_timestamp: false\n    metrics:\n    - aws_namespace: AWS/ES\n      aws_metric_name: FreeStorageSpace\n      aws_dimensions: [ClientId, DomainName]\n      aws_dimension_select:\n        DomainName: [TL-staging-logs]\n      aws_statistics: [Minimum, Maximum, Average, Sum]\n"
      filename:    "helm-values.yaml"

Plan: 1 to add, 0 to change, 0 to destroy.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
