### PR TITLE
Fix cognito setup - set params empty

### DIFF
--- a/elasticsearch/main.tf
+++ b/elasticsearch/main.tf
@@ -78,9 +78,9 @@ resource "aws_elasticsearch_domain" "es" {
 
   cognito_options {
     enabled          = var.cognito_enabled
-    user_pool_id     = var.cognito_user_pool_id
-    identity_pool_id = var.cognito_identity_pool_id
-    role_arn         = var.cognito_role_arn
+    user_pool_id     = var.cognito_enabled ? var.cognito_user_pool_id : ""
+    identity_pool_id = var.cognito_enabled ? var.cognito_identity_pool_id : ""
+    role_arn         = var.cognito_enabled ? var.cognito_role_arn : ""
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Small fix needed for deploying ES without cognito enabled. If the cognito block is set, you're required to set the parameters (thus empty string works).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
