### PR TITLE
Add multi-az configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Terraform module to setup all resources needed for setting up an AWS Elasticsear
 | volume\_size | EBS volume size (in GB) to use for the Elasticsearch domain | number | n/a | yes |
 | volume\_type | EBS volume type to use for the Elasticsearch domain | string | `"gp2"` | no |
 | vpc\_id | VPC ID where to deploy the Elasticsearch domain. If set, you also need to specify `subnet_ids`. If not set, the module creates a public domain | string | `null` | no |
-| zone\_awareness\_enabled | Whether to enable zone_awareness or not | bool | `false` | no |
+| zone\_awareness\_enabled | Whether to enable zone_awareness or not, if not set, multi az is enabled by default and configured through number of instances/subnets available | bool | `null` | no |
+| availability\_zone\_count | Number of Availability Zones for the domain to use with zone_awareness_enabled.Valid values: 2 or 3. Automatically configured through number of instances/subnets available if not set | number | `null` | no 
 
 ### Outputs
 

--- a/elasticsearch/main.tf
+++ b/elasticsearch/main.tf
@@ -30,7 +30,6 @@ locals {
 
   # For private domains, get number of multiple zones instances can span within available subnets
   subnet_az = var.instance_count >= 3 && length(distinct(data.aws_subnet.private[*].availability_zone)) >= 3 ? 3 : var.instance_count >= 2 && length(distinct(data.aws_subnet.private[*].availability_zone)) >= 2 ? 2 : null
-  
 
   zone_awareness_enabled = local.instance_az != null ? true : local.subnet_az != null ? true : false
 
@@ -49,7 +48,7 @@ resource "aws_elasticsearch_domain" "es" {
     dedicated_master_type    = var.dedicated_master_enabled ? var.dedicated_master_type : ""
     zone_awareness_enabled   = var.zone_awareness_enabled != null ? var.zone_awareness_enabled : local.zone_awareness_enabled
     dynamic "zone_awareness_config" {
-      for_each = var.zone_awareness_enabled != null ? var.zone_awareness_enabled : local.zone_awareness_enabled
+      for_each = var.zone_awareness_enabled == true || local.zone_awareness_enabled == true ? [1] : []
       content {
         availability_zone_count = var.availability_zone_count != null ? var.availability_zone_count : local.availability_zone_count
       }

--- a/elasticsearch/main.tf
+++ b/elasticsearch/main.tf
@@ -29,8 +29,8 @@ locals {
   instance_az = var.vpc_id == null && var.instance_count >= 3 ? 3 : var.vpc_id == null && var.instance_count == 2 ? 2 : null
 
   # For private domains, get number of multiple zones instances can span within available subnets
-  #subnet_az = var.instance_count >= 3 && length(distinct(data.aws_subnet.private[*].availability_zone)) >= 3 ? 3 : var.instance_count >= 2 && length(distinct(data.aws_subnet.private[*].availability_zone)) >= 2 ? 2 : null
-  subnet_az = var.instance_count >= 3 && length(distinct(var.subnet_ids)) >= 3 ? 3 : var.instance_count >= 2 && length(distinct(var.subnet_ids)) >= 2 ? 2 : null
+  subnet_az = var.instance_count >= 3 && length(distinct(data.aws_subnet.private[*].availability_zone)) >= 3 ? 3 : var.instance_count >= 2 && length(distinct(data.aws_subnet.private[*].availability_zone)) >= 2 ? 2 : null
+  
 
   zone_awareness_enabled = local.instance_az != null ? true : local.subnet_az != null ? true : false
 

--- a/elasticsearch/outputs.tf
+++ b/elasticsearch/outputs.tf
@@ -1,21 +1,21 @@
 output "arn" {
   description = "ARN of the Elasticsearch domain"
-  value = aws_elasticsearch_domain.es.arn
+  value       = aws_elasticsearch_domain.es.arn
 }
 
 output "domain_id" {
   description = "ID of the Elasticsearch domain"
-  value = aws_elasticsearch_domain.es.domain_id
+  value       = aws_elasticsearch_domain.es.domain_id
 }
 
 output "domain_name" {
   description = "Name of the Elasticsearch domain"
-  value = aws_elasticsearch_domain.es.domain_name
+  value       = aws_elasticsearch_domain.es.domain_name
 }
 
 output "endpoint" {
   description = "DNS endpoint of the Elasticsearch domain"
-  value = aws_elasticsearch_domain.es.endpoint
+  value       = aws_elasticsearch_domain.es.endpoint
 }
 
 output "domain_region" {

--- a/elasticsearch/variables.tf
+++ b/elasticsearch/variables.tf
@@ -99,8 +99,14 @@ variable "dedicated_master_enabled" {
 
 variable "zone_awareness_enabled" {
   type        = bool
-  description = "Whether to enable zone_awareness or not"
-  default     = false
+  description = "Whether to enable zone_awareness or not, if not set, multi az is enabled by default and configured through number of instances/subnets available"
+  default     = null
+}
+
+variable "availability_zone_count" {
+  type        = number
+  description = "Number of Availability Zones for the domain to use with zone_awareness_enabled.Valid values: 2 or 3. Automatically configured through number of instances/subnets available if not set."
+  default     = null
 }
 
 variable "dedicated_master_type" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds functionality to configure AZ deployment to always enable it at maximum level possible within available resources, unless specified otherwise by user 
 
## Description
<!--- Describe your changes in detail -->
- Allow user to enable/disable multi-az
- Allow user to configure multi-az deployment across 2 or 3 zones
- If the above is not specified, set multi-az and configure number of zones based on provided instance count and subnets available for private domains

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/engineering/issues/236


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All expressions are tested manually using terraform console against several use cases for validation 
