### PR TITLE
Use dynamic block for ES_APPLICATION_LOGS

### DIFF
--- a/elasticsearch/main.tf
+++ b/elasticsearch/main.tf
@@ -41,8 +41,8 @@ resource "aws_elasticsearch_domain" "es" {
   elasticsearch_version = var.elasticsearch_version
 
   cluster_config {
-    instance_count           = var.instance_count
-    instance_type            = var.instance_type
+    instance_count = var.instance_count
+    instance_type  = var.instance_type
 
     dedicated_master_enabled = var.warm_enabled || var.dedicated_master_enabled
     dedicated_master_count   = var.warm_enabled || var.dedicated_master_enabled ? var.dedicated_master_count : null
@@ -52,7 +52,7 @@ resource "aws_elasticsearch_domain" "es" {
     warm_count   = var.warm_enabled ? var.warm_count : null
     warm_type    = var.warm_enabled ? var.warm_type : null
 
-    zone_awareness_enabled   = var.zone_awareness_enabled != null ? var.zone_awareness_enabled : local.zone_awareness_enabled
+    zone_awareness_enabled = var.zone_awareness_enabled != null ? var.zone_awareness_enabled : local.zone_awareness_enabled
 
     dynamic "zone_awareness_config" {
       for_each = var.zone_awareness_enabled == true || local.zone_awareness_enabled == true ? [1] : []
@@ -107,10 +107,14 @@ resource "aws_elasticsearch_domain" "es" {
     cloudwatch_log_group_arn = aws_cloudwatch_log_group.cwl_search.arn
   }
 
-  log_publishing_options {
-    enabled                  = var.application_logging_enabled
-    log_type                 = "ES_APPLICATION_LOGS"
-    cloudwatch_log_group_arn = aws_cloudwatch_log_group.cwl_application.arn
+  dynamic "log_publishing_options" {
+    for_each = var.application_logging_enabled ? ["ES_APPLICATION_LOGS"] : []
+
+    content {
+      enabled                  = true
+      log_type                 = "ES_APPLICATION_LOGS"
+      cloudwatch_log_group_arn = aws_cloudwatch_log_group.cwl_application.arn
+    }
   }
 
   dynamic "vpc_options" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the `ES_APPLICATION_LOGS` `log_publishing_options` to a dynamic block so it doesn't get defined when `application_logging_enabled = false`. This is needed because older AWS ES versions (2.3) don't support setting this.
 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Applied

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
