### PR TITLE
Disable indices scraping in ES prometheus exporter

### DIFF
--- a/elasticsearch_k8s_monitoring/templates/elasticsearch-monitoring-values.yaml.tpl
+++ b/elasticsearch_k8s_monitoring/templates/elasticsearch-monitoring-values.yaml.tpl
@@ -11,6 +11,7 @@ prometheus-elasticsearch-exporter:
     uri: ${elasticsearch_endpoint}
     indices: false
     indices_settings: false
+    shards: false
 
 prometheus-cloudwatch-exporter:
   resources:

--- a/elasticsearch_k8s_monitoring/templates/elasticsearch-monitoring-values.yaml.tpl
+++ b/elasticsearch_k8s_monitoring/templates/elasticsearch-monitoring-values.yaml.tpl
@@ -9,6 +9,8 @@ prometheus-elasticsearch-exporter:
       memory: 48Mi
   es:
     uri: ${elasticsearch_endpoint}
+    indices: false
+    indices_settings: false
 
 prometheus-cloudwatch-exporter:
   resources:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Disable indices scraping in ES prometheus exporter

We don't really use indices metrics and the exporter is not scaling well on clusters with a huge amount of indices.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
