### PR TITLE
Fix backup lambda creation

### DIFF
--- a/opensearch/backups.tf
+++ b/opensearch/backups.tf
@@ -212,6 +212,13 @@ resource "aws_iam_role_policy" "snapshot_lambda" {
   policy = data.aws_iam_policy_document.snapshot_lambda[0].json
 }
 
+resource "aws_iam_role_policy_attachment" "snapshot_lambda_exec_role" {
+  count = local.snapshot_enabled_count
+
+  role       = aws_iam_role.snapshot_lambda[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
 ## SG
 
 resource "aws_security_group" "snapshot_lambda" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Sometimes AWS gives an error when creating a lambda function without this role, even if the role already has the necessary permissions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
